### PR TITLE
Resto Widget size tweaks

### DIFF
--- a/android/src/be/ugent/zeus/hydra/widget/RestoMenuWidgetProvider.java
+++ b/android/src/be/ugent/zeus/hydra/widget/RestoMenuWidgetProvider.java
@@ -5,6 +5,8 @@
  */
 package be.ugent.zeus.hydra.widget;
 
+import java.util.Calendar;
+
 import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
@@ -13,6 +15,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.os.ResultReceiver;
+import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.RemoteViews;
 import be.ugent.zeus.hydra.R;
@@ -20,7 +23,6 @@ import be.ugent.zeus.hydra.RestoMenu;
 import be.ugent.zeus.hydra.data.Menu;
 import be.ugent.zeus.hydra.data.services.MenuService;
 import be.ugent.zeus.hydra.ui.menu.MenuView;
-import java.util.Calendar;
 
 public class RestoMenuWidgetProvider extends AppWidgetProvider {
 
@@ -31,6 +33,9 @@ public class RestoMenuWidgetProvider extends AppWidgetProvider {
     // These two are mutually exclusive, if they both are enabled it's FCFS.
     private static final boolean OPENAPPONCLICK = true;
     private static final boolean REFRESHONCLICK = false;
+    
+    private int width=350;
+    private int height=450;
 
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
@@ -40,6 +45,11 @@ public class RestoMenuWidgetProvider extends AppWidgetProvider {
 
         // Get the layout for the App Widget
         views = new RemoteViews(context.getPackageName(), R.layout.widget_restomenu);
+        
+        // Calculate a fitting size for the user's screensize
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+        width = (int) (metrics.widthPixels * 0.65);
+        height = (int) (metrics.heightPixels * 0.65);
 
         // Send intent to retrieve Menu data for today
         Intent menuIntent = new Intent(context, MenuService.class);
@@ -93,8 +103,8 @@ public class RestoMenuWidgetProvider extends AppWidgetProvider {
                     }
                     else {
 	                    View view = new MenuView(context, menu);
-	                    view.measure(350, 450);
-	                    view.layout(0, 0, 350, 450);
+	                    view.measure(width, height);
+	                    view.layout(0, 0, width, height);
 	
 	                    // Get a bitmap from the View and add it to the ImageView of our Widget
 	                    view.setDrawingCacheEnabled(true);


### PR DESCRIPTION
I changed the way the size of the bitmap of the widget is calculated, but since I only have one device, I can't really check if it'll work other screen resolution.
