### PR TITLE
Add ecological sandwiches to scraper

### DIFF
--- a/api-resto-02.md
+++ b/api-resto-02.md
@@ -26,6 +26,7 @@ All scraped data available in this API is also available as a [git repository](h
 ## Changelog
 
 - _April 2019_ - Added new `message` field to menu to indicate closures and changes in meals.
+- _September 2019_ - Added ecological sandwich of the week
 
 ## Technical description
 

--- a/api-resto-02.md
+++ b/api-resto-02.md
@@ -313,7 +313,7 @@ Lists all sandwiches which were or are available in the specified year. Sample o
 | `ingredients` | A list of the ingredients in the sandwich.
 | `name` | The name of the sandwich.
 | `start` | Inclusive start date on which the sandwich is available. The date's format follows ISO 8601:2004's extended format (YYYY-MM-DD).
-| `end` | Inclusive start date on which the sandwich is available. The date's format follows ISO 8601:2004's extended format (YYYY-MM-DD).
+| `end` | Inclusive end date on which the sandwich is available. The date's format follows ISO 8601:2004's extended format (YYYY-MM-DD).
 | `vegan` | Boolean indicating if the sandwich is vegan or not (not to be confused with vegetarian).
 
 

--- a/api-resto-02.md
+++ b/api-resto-02.md
@@ -32,10 +32,13 @@ All scraped data available in this API is also available as a [git repository](h
 | Endpoint                              | Description                    |
 |---------------------------------------|--------------------------------|
 | [`GET /meta.json`](#metadata)         | Information about the restos. |
-| [`GET /sandwiches.json`](#sandwiches) | List of available sandwiches.   |
 | [`GET /extrafood.json`](#extra-food)  | List of additional available items, such as breakfast or desserts. |
-| [`GET /menu/{endpoint}/overview.json`](#overview) | The future menu for a specific resto. |
+| [`GET /menu/{endpoint}/overview.json`](#overview-menu) | The future menu for a specific resto. |
 | [`GET /menu/{endpoint}/{year}/{month}/{day}.json`](#day-menu) | The menu for a particular day. |
+| `GET /sandwiches.json` | (deprecated)   |
+| [`GET /sandwiches/static.json`](#regular-sandwiches)         | List of normal sandwiches. |
+| [`GET /sandwiches/overview.json`](#weekly-sandwiches-overview)         | Upcoming ecological sandwiches. |
+| [`GET /sandwiches/{year}.json`](#weekly-sandwiches-yearly)         | All ecological sandwiches. |
 
 Date and hour specifiers are from ISO 8601:2014.
 
@@ -86,37 +89,6 @@ The response is an object with one field, `locations`, a list of locations.
 | `endpoint` | The endpoint for this resto. Can be used in `/resto/menu/{ENDPOINT}`. See [Overview](#overview) or [Day menu](#day-menu).
 | `open` | Lists the intervals in which this location is open, for each type of the location. Uses ISO 8601:2014's extended format with reduced accuracy (`hh:mm`). These are the regular opening hours; holidays and other exceptional closures are not accounted for.
 
-### Sandwiches
-
-**Endpoint**: `GET /sandwiches.json`
-
-Lists available sandwiches, their price and their ingredients. Sample output:
-
-
-```json
-[
-  {
-    "ingredients": [
-      "brie",
-      "honing",
-      "pijnboompitten",
-      "sla"
-    ],
-    "name": "Brie",
-    "price_medium": "2.40",
-    "price_small": "1.50"
-  }
-]
-```
-
-| Field | Description
-|-------|-------------
-| `ingredients` | A list of the ingredients in the sandwich.
-| `name` | The name of the sandwich.
-| `price_medium` | The (textual) price in euros for a normal sandwich.
-| `price_medium` | The (textual) price in euros for a small sandwich.
-
-
 ### Extra food
 
 **Endpoint**: `GET /extrafood.json`
@@ -150,7 +122,7 @@ There are three lists in the response: `breakfast`, `desserts` and `drinks`. Eac
 
 _Note_: the price format is not identical as the price format used by the [Day Menu](#day-menu) output.
 
-### Overview
+### Overview menu
 
 **Endpoint**: `GET \menu\{endpoint}\overview.json`
 
@@ -274,4 +246,75 @@ A meal object consists of:
 
 How an application handles changes to possible values (indicated above where this is applicable), is not specified.
 The application might simply ignore new values.
+
+### Regular sandwiches
+
+**Endpoint**: `GET /sandwiches/static.json`
+
+Lists available regular sandwiches, their price and their ingredients. Sample output:
+
+
+```json
+[
+  {
+    "ingredients": [
+      "brie",
+      "honing",
+      "pijnboompitten",
+      "sla"
+    ],
+    "name": "Brie",
+    "price_medium": "2.40",
+    "price_small": "1.50"
+  }
+]
+```
+
+| Field | Description
+|-------|-------------
+| `ingredients` | A list of the ingredients in the sandwich.
+| `name` | The name of the sandwich.
+| `price_medium` | The (textual) price in euros for a normal sandwich.
+| `price_medium` | The (textual) price in euros for a small sandwich.
+
+### Weekly sandwiches overview
+
+**Endpoint**: `GET /sandwiches/overview.json`
+
+Lists all upcoming ecological sandwiches of the week ("ecologisch broodje van de week"). Output is in the same format as [Weekly sandwiches yearly](#weekly-sandwiches-yearly).
+
+### Weekly sandwiches yearly
+
+**Endpoint**: `GET /sandwiches/{year}.json`
+
+**Parameters**:
+- _year_ -- Which year you want the sandwiches of. Values must be a positive integer. Currently, the earliest available year is 2019 (but this might change in the future). ISO format: `YYYY`.
+
+Lists all sandwiches which were or are available in the specified year. Sample output:
+
+```json
+[
+  {
+    "start": "2019-09-16",
+    "end": "2019-09-20",
+    "ingredients": [
+      "gebakken champignons met tofu (soja)",
+      "mayonaise",
+      "basilicum"
+    ],
+    "name": "Champignonsalade",
+    "vegan": false
+  }
+]
+```
+
+| Field | Description
+|-------|-------------
+| `ingredients` | A list of the ingredients in the sandwich.
+| `name` | The name of the sandwich.
+| `start` | Inclusive start date on which the sandwich is available. The date's format follows ISO 8601:2004's extended format (YYYY-MM-DD).
+| `end` | Inclusive start date on which the sandwich is available. The date's format follows ISO 8601:2004's extended format (YYYY-MM-DD).
+| `vegan` | Boolean indicating if the sandwich is vegan or not (not to be confused with vegetarian).
+
+
 

--- a/server/scraper/resto/all.sh
+++ b/server/scraper/resto/all.sh
@@ -57,10 +57,13 @@ command="$dir/menu_manual.py $output2"
 # shellcheck disable=2086
 eval ${command}
 
-echo "Eating all the sandwiches"
+echo "Scraping sandwiches"
 command="$dir/sandwiches.py $output1 $output2"
 # shellcheck disable=2086
 eval ${command}
+# Symlink old file for compatibility reasons
+rm -f "$output2/sandwiches.json"
+ln -s "$output2/sandwiches/static.json" "$output2/sandwiches.json"
 
 echo "Finding all the desserts"
 command="$dir/cafetaria.py $output2"

--- a/server/scraper/resto/sandwiches.py
+++ b/server/scraper/resto/sandwiches.py
@@ -2,6 +2,10 @@
 import argparse
 import os
 import requests
+import re
+import datetime
+import json
+from collections import defaultdict
 from bs4 import BeautifulSoup
 
 # Bad python module system
@@ -13,28 +17,72 @@ from util import parse_money, write_json_to_file
 SANDWICHES_URL = "https://www.ugent.be/student/nl/meer-dan-studeren/resto/broodjes/overzicht.htm"
 HTML_PARSER = 'lxml'
 
-
-def parse_ingredients(columns, ingredients):
-    return [ingredient.strip().lower()
-            for ingredient
-            in columns[1].string.replace(' en ', ',').split(',')]
+STATIC_SANDWICHES = "sandwiches/static.json"
+UPCOMING_SANDWICHES = "sandwiches/overview.json"
+YEARLY_SANDWICHES = "sandwiches/{}.json"
 
 
-def main(output1, output2):
+def parse_ingredients(ingredients):
+    return [ingredient.strip().lower() for ingredient in ingredients.replace(' en ', ',').split(',')]
+
+
+def guess_year(sandwich_month):
+    today = datetime.date.today()
+    current_month = today.month
+
+    if 9 <= current_month <= 12:
+        if 9 <= sandwich_month <= 12:
+            return today.year
+        else:
+            assert 1 <= sandwich_month <= 8
+            return today.year + 1
+    else:
+        assert 1 <= current_month <= 8
+        if 9 <= sandwich_month <= 12:
+            return today.year - 1
+        else:
+            assert 1 <= sandwich_month <= 8
+            return today.year
+
+
+def parse_dates(week):
+    """
+    Parse raw dates on the website to complete dates:
+    - if current month is between september-december and sandwich date also, use current year
+    - if current month is between september-december and sandwich date is between januari-august, use current year+1
+    - if current month is between januari-august and sandwich date is between september-december, use current year-1
+    - if current month is between januari-august and sandwich date also, use current year
+    """
+    pattern = r"\s*/?\s*(?P<start_day>\d+)\s*[/\-]\s*(?P<start_month>\d+)\s*/?\s*-\s*/?\s*(?P<end_day>\d+)\s*[/\-]\s*(?P<end_month>\d+)\s*/?\s*"
+    regex = re.compile(pattern)
+    match = regex.search(week)
+
+    start_day = int(match.group('start_day'))
+    start_month = int(match.group('start_month'))
+    start_year = guess_year(start_month)
+    end_day = int(match.group('end_day'))
+    end_month = int(match.group('end_month'))
+    end_year = guess_year(end_month)
+    start_date = datetime.date(start_year, start_month, start_day)
+    end_date = datetime.date(end_year, end_month, end_day)
+
+    return start_date, end_date
+
+
+def static_sandwiches(output1, output2, soup):
     """
     Parse sandwiches from the menu.
     :param output1: The root output folder for v1.
     :param output2: The root output folder for v2.
+    :param soup: BeautifulSoup of the page with the data.
     """
-    r = requests.get(SANDWICHES_URL)
-    soup = BeautifulSoup(r.text, HTML_PARSER)
     sandwiches = []
 
     for row in soup.table.find_all("tr", class_=lambda x: x != 'tabelheader'):
         columns = row.find_all("td")
         sandwiches.append({
             "name": columns[0].find(text=True),
-            "ingredients": parse_ingredients(columns, columns[1].string),
+            "ingredients": parse_ingredients(columns[1].string),
             "price_small": parse_money(columns[2].string),
             "price_medium": parse_money(''.join(columns[3].findAll(text=True)))  # workaround
         })
@@ -42,8 +90,76 @@ def main(output1, output2):
     # The output is the same in version 1 and version 2.
     output_file1 = os.path.join(output1, "sandwiches.json")
     write_json_to_file(sandwiches, output_file1)
-    output_file2 = os.path.join(output2, "sandwiches.json")
+    output_file2 = os.path.join(output2, STATIC_SANDWICHES)
     write_json_to_file(sandwiches, output_file2)
+
+
+def weekly_sandwiches(output, soup):
+    """
+    Parse the weekly sandwiches.
+
+    :param soup: BeautifulSoup of the page with the data.
+    :param output: The root output for the sandwiches.
+    """
+
+    sandwiches = []
+
+    for row in soup.find_all('table', limit=2)[1].find_all("tr", class_=lambda x: x != 'tabelheader'):
+        columns = row.find_all("td")
+        start, end = parse_dates(columns[0].text)
+        sandwiches.append({
+            'start': start,
+            'end': end,
+            'name': columns[1].text.strip(),
+            'ingredients': parse_ingredients(columns[2].text),
+            'vegan': 'x' in columns[3].text
+        })
+
+    today = datetime.date.today()
+    # Write upcoming sandwiches to overview
+    upcoming = [sandwich['end'] >= today for sandwich in sandwiches]
+    upcoming_output = os.path.join(output, UPCOMING_SANDWICHES)
+    write_json_to_file(upcoming, upcoming_output)
+
+    # Sort into years
+    yearly_sandwiches = defaultdict(list)
+    for s in sandwiches:
+        yearly_sandwiches[s['start'].year].append(s)
+
+    for year, s in yearly_sandwiches.items():
+        # Read existing file if present.
+        output_file = os.path.join(output, YEARLY_SANDWICHES.format(year))
+        try:
+            with open(output_file, 'r') as file:
+                existing = json.load(file)
+        except (FileNotFoundError, json.decoder.JSONDecodeError):
+            existing = []
+
+        # Filter outdated sandwiches: those with an existing start or end date.
+        start_dates = [sandwich['start'] for sandwich in s]
+        end_dates = [sandwich['end'] for sandwich in s]
+        existing = [x for x in existing
+                    if not (datetime.date.fromisoformat(x['start']) in start_dates
+                            or datetime.date.fromisoformat(x['end']) in end_dates)]
+        existing.extend(s)
+        for sandwich in existing:
+            sandwich['start'] = sandwich['start'].isoformat()
+            sandwich['end'] = sandwich['end'].isoformat()
+        write_json_to_file(existing, output_file)
+
+
+def all_sandwiches(output1, output2):
+    """
+    Get all sandwiches.
+    :param output1: The root output folder for v1.
+    :param output2: The root output folder for v2.
+    """
+
+    r = requests.get(SANDWICHES_URL)
+    soup = BeautifulSoup(r.text, HTML_PARSER)
+
+    static_sandwiches(output1, output2, soup)
+    weekly_sandwiches(output2, soup)
 
 
 if __name__ == "__main__":
@@ -59,4 +175,4 @@ if __name__ == "__main__":
     output_path2 = os.path.abspath(args.output2)
     os.makedirs(output_path2, exist_ok=True)
 
-    main(output_path1, output_path2)
+    all_sandwiches(output_path1, output_path2)

--- a/server/scraper/resto/sandwiches.py
+++ b/server/scraper/resto/sandwiches.py
@@ -117,7 +117,10 @@ def weekly_sandwiches(output, soup):
 
     today = datetime.date.today()
     # Write upcoming sandwiches to overview
-    upcoming = [sandwich['end'] >= today for sandwich in sandwiches]
+    upcoming = [sandwich.copy() for sandwich in sandwiches if sandwich['end'] >= today]
+    for sandwich in upcoming:
+        sandwich['start'] = sandwich['start'].isoformat()
+        sandwich['end'] = sandwich['end'].isoformat()
     upcoming_output = os.path.join(output, UPCOMING_SANDWICHES)
     write_json_to_file(upcoming, upcoming_output)
 


### PR DESCRIPTION
- View the proposed API in the docs [here](https://github.com/ZeusWPI/hydra/blob/bfb5476310553f95827683d3e91b5942f3a782b3/api-resto-02.md).
- Data will also be saved in the [data repo](https://git.zeus.gent/hydra/data)
- The scraper runs with the normal resto scraper (so each day, which was already the case for the *static* sandwiches)

Feedback or suggestions welcome.