### PR TITLE
Update scraper for Corona

### DIFF
--- a/api-resto-01.md
+++ b/api-resto-01.md
@@ -14,18 +14,16 @@ This document describes version 1.0 of the API.
 
 | Version                | Endpoint                                   | Status     |
 |------------------------|--------------------------------------------|------------|
-| 1.0 (this)             | https://zeus.ugent.be/hydra/api/1.0/resto/ | deprecated |
+| 1.0 (this)             | https://zeus.ugent.be/hydra/api/1.0/resto/ | retired    |
 | [2.0](api-resto-02.md) | https://zeus.ugent.be/hydra/api/2.0/resto/ | current    |
 
-This API is deprecated. Applications are encouraged to migrate to version 2.0 of the API.
+Applications are encouraged to migrate to version 2.0 of the API.
 
-This means that although there are currently no concrete plans to retire the API, the API is no longer developed. New features will not be added and bugs may not be fixed.
+This API is retired. Existing data will continue to be served for now, but the data is no longer updated.
 
 ## Data dump
 
 All scraped data available in this API is also available as a [git repository](https://git.zeus.gent/hydra/data). If you need all available data, it is probably easier and faster to download or clone the repo.
-
-If or when this version of the API is sunset, the data will remain available in the repo above.
 
 ## Technical description
 

--- a/api-resto-02.md
+++ b/api-resto-02.md
@@ -1,4 +1,4 @@
-# Resto API 2.0
+# Resto API 2.3
 
 ## Introduction
 
@@ -16,8 +16,8 @@ This document describes the current version of the API, version 2.0.
 
 | Version                | Endpoint                                   | Status     |
 |------------------------|--------------------------------------------|------------|
-| [1.0](api-resto-01.md) | https://zeus.ugent.be/hydra/api/1.0/resto/ | deprecated |
-| 2.0 (this)             | https://zeus.ugent.be/hydra/api/2.0/resto/ | current    |
+| [1.0](api-resto-01.md) | https://zeus.ugent.be/hydra/api/1.0/resto/ | retired |
+| 2.3 (this)             | https://zeus.ugent.be/hydra/api/2.0/resto/ | current    |
 
 ## Data dump
 
@@ -25,21 +25,27 @@ All scraped data available in this API is also available as a [git repository](h
 
 ## Changelog
 
-- _April 2019_ - Added new `message` field to menu to indicate closures and changes in meals.
-- _September 2019_ - Added ecological sandwich of the week
+- _April 2019_ - Added new `message` field to menu to indicate closures and changes in meals. (2.1)
+- _September 2019_ - Added ecological sandwich of the week (2.2)
+- _September 2020_ - Corona update (2.3):
+  - The meal type `side` is no longer used.
+  - A new meal type is present: `cold`.
+  - Add a new endpoint for salad bowls.
+  - API 1.0 has been retired.
 
 ## Technical description
 
-| Endpoint                              | Description                    |
-|---------------------------------------|--------------------------------|
-| [`GET /meta.json`](#metadata)         | Information about the restos. |
-| [`GET /extrafood.json`](#extra-food)  | List of additional available items, such as breakfast or desserts. |
-| [`GET /menu/{endpoint}/overview.json`](#overview-menu) | The future menu for a specific resto. |
-| [`GET /menu/{endpoint}/{year}/{month}/{day}.json`](#day-menu) | The menu for a particular day. |
-| `GET /sandwiches.json` | (deprecated)   |
-| [`GET /sandwiches/static.json`](#regular-sandwiches)         | List of normal sandwiches. |
-| [`GET /sandwiches/overview.json`](#weekly-sandwiches-overview)         | Upcoming ecological sandwiches. |
-| [`GET /sandwiches/{year}.json`](#weekly-sandwiches-yearly)         | All ecological sandwiches. |
+| Endpoint                                                          | Description                    |
+|-------------------------------------------------------------------|--------------------------------|
+| [`GET /meta.json`](#metadata)                                     | Information about the resto's. |
+| [`GET /extrafood.json`](#extra-food)                              | List of additional available items, such as breakfast or desserts. |
+| [`GET /menu/{endpoint}/overview.json`](#overview-menu)            | The future menu for a specific resto. |
+| [`GET /menu/{endpoint}/{year}/{month}/{day}.json`](#day-menu)     | The menu for a particular day. |
+| `GET /sandwiches.json`                                            | (deprecated)   |
+| [`GET /sandwiches/static.json`](#regular-sandwiches)              | List of normal sandwiches. |
+| [`GET /sandwiches/overview.json`](#weekly-sandwiches-overview)    | Upcoming ecological sandwiches. |
+| [`GET /sandwiches/{year}.json`](#weekly-sandwiches-yearly)        | All ecological sandwiches. |
+| [`GET /salads.json`](#salad-bowls)                                | Available salad bowls |
 
 Date and hour specifiers are from ISO 8601:2014.
 
@@ -276,7 +282,7 @@ Lists available regular sandwiches, their price and their ingredients. Sample ou
 | `ingredients` | A list of the ingredients in the sandwich.
 | `name` | The name of the sandwich.
 | `price_medium` | The (textual) price in euros for a normal sandwich.
-| `price_medium` | The (textual) price in euros for a small sandwich.
+| `price_small` | The (textual) price in euros for a small sandwich.
 
 ### Weekly sandwiches overview
 
@@ -290,6 +296,8 @@ Lists all upcoming ecological sandwiches of the week ("ecologisch broodje van de
 
 **Parameters**:
 - _year_ -- Which year you want the sandwiches of. Values must be a positive integer. Currently, the earliest available year is 2019 (but this might change in the future). ISO format: `YYYY`.
+
+Starting in academic year 2020-2021, this is listed as "groentespread".
 
 Lists all sandwiches which were or are available in the specified year. Sample output:
 
@@ -318,4 +326,25 @@ Lists all sandwiches which were or are available in the specified year. Sample o
 | `vegan` | Boolean indicating if the sandwich is vegan or not (not to be confused with vegetarian).
 
 
+### Salad bowls
 
+**Endpoint**: `GET /salads.json`
+
+Lists available salad bowls, their price and a description. Sample output:
+
+
+```json
+[
+  {
+    "description": "Assortiment groenten, mozzarella, tomaat, basilicum pesto en sla",
+    "name": "Tomaat-mozzarella",
+    "price": "3.00"
+  }
+]
+```
+
+| Field | Description
+|-------|-------------
+| `description` | A description of the salad bowl. Often contains information about ingredients.
+| `name` | The name of the salad bowl.
+| `price` | The price in euros for a normal sandwich (this is a string).

--- a/server/scraper/resto/all.sh
+++ b/server/scraper/resto/all.sh
@@ -48,7 +48,7 @@ pushd "$dir"
 
 # Run scraper
 echo "Scraping all the menus"
-command="$dir/menu.py $output1 $output2"
+command="$dir/menu.py $output2"
 # shellcheck disable=2086
 eval ${command}
 
@@ -58,7 +58,7 @@ command="$dir/menu_manual.py $output2"
 eval ${command}
 
 echo "Scraping sandwiches"
-command="$dir/sandwiches.py $output1 $output2"
+command="$dir/sandwiches.py $output2"
 # shellcheck disable=2086
 eval ${command}
 # Symlink old file for compatibility reasons

--- a/server/scraper/resto/menu.py
+++ b/server/scraper/resto/menu.py
@@ -31,7 +31,8 @@ WEEK_MENU_URL = {
     "en": "https://www.ugent.be/en/facilities/restaurants/weekly-menu/overzicht/@@rss2json",
     "nl-debrug": LINK_FORMAT.format("weekmenurestodebrug"),
     "nl-heymans": LINK_FORMAT.format("weekmenurestocampusheymans"),
-    "nl-kantienberg": LINK_FORMAT.format("weekmenurestokantienberg")
+    # Closed for this year.
+    #"nl-kantienberg": LINK_FORMAT.format("weekmenurestokantienberg")
 }
 
 # Define the page type for the resto.
@@ -97,8 +98,14 @@ HEADING_TO_TYPE = {
     'soup': 'soup',
     'meal soup': 'meal soup',
     'main dish': 'meat',
-    'vegetables': 'vegetables'
+    'vegetables': 'vegetables',
+    'warme gerechten': 'meat',
+    'koude gerechten (zelf op te warmen)': 'meat'
 }
+
+HOT_COLD_MAPPING = collections.defaultdict(lambda: 'hot', {
+    'koude gerechten (zelf op te warmen)': 'cold'
+})
 
 
 def get_weeks_rss_json(url):
@@ -220,31 +227,32 @@ def get_day_menu(which, url):
             name, price = split_price(meal)
             soups.append(dict(price=price, name=name, type='main'))
         elif HEADING_TO_TYPE[last_heading] == 'meat':
+            hot_cold = HOT_COLD_MAPPING[last_heading]
             name, price = split_price(meal)
             if ':' in meal:  # Meat in the old way
                 kind, name = [s.strip() for s in name.split(':')]
                 kind = kind.lower()
                 kind = TRANSLATE_KIND[kind]
-                meats.append(dict(price=price, name=name, kind=kind))
+                meats.append(dict(price=price, name=name, kind=kind, hot=hot_cold))
             else:  # Meat in the new way
                 # If the name contains '-', it might be an indication of vegan/vegi
                 if '-' in name:
                     kind = name.split('-')[-1].strip()
                     stripped_name = '-'.join(name.split('-')[:-1]).strip()  # Re-join other splits
                     if kind in TRANSLATE_KIND:
-                        meats.append(dict(price=price, name=stripped_name, kind=TRANSLATE_KIND[kind]))
+                        meats.append(dict(price=price, name=stripped_name, kind=TRANSLATE_KIND[kind], hot=hot_cold))
                     else:
-                        meats.append(dict(price=price, name=name, kind='meat'))
+                        meats.append(dict(price=price, name=name, kind='meat', hot=hot_cold))
                 else:
                     # Sometimes there is vegan/vegetarian in the name, in which case they don't repeat the type.
                     if any(possible in name.lower() for possible in POSSIBLE_VEGETARIAN):
-                        meats.append(dict(price=price, name=name, kind='vegetarian'))
+                        meats.append(dict(price=price, name=name, kind='vegetarian', hot=hot_cold))
                     elif any(possible in name.lower() for possible in POSSIBLE_VEGAN):
-                        meats.append(dict(price=price, name=name, kind='vegan'))
+                        meats.append(dict(price=price, name=name, kind='vegan', hot=hot_cold))
                     elif any(possible in name.lower() for possible in POSSIBLE_FISH):
-                        meats.append(dict(price=price, name=name, kind='fish'))
+                        meats.append(dict(price=price, name=name, kind='fish', hot=hot_cold))
                     else:
-                        meats.append(dict(price=price, name=name, kind='meat'))
+                        meats.append(dict(price=price, name=name, kind='meat', hot=hot_cold))
         elif HEADING_TO_TYPE[last_heading] == 'vegetables':
             vegetables.append(meal)
         else:
@@ -312,51 +320,6 @@ class DateStuff(object):
         return DateStuff.iso_to_gregorian(iso_year, iso_week, iso_day)
 
 
-def write_1_0(root_path, menus, use_existing=True):
-    """
-    Write the menus for version 1.0 of the API. This is Dutch only.
-    :param use_existing: If existing data should be deleted or not. Set to true if re-writing all data.
-    :param root_path: The output path for version 1.0. This is the root path. The subfolder menu will be created.
-    :param menus: The menus to write.
-    """
-    for week_year, week_menu in menus['nl'].items():
-        year, week = week_year
-        # Read existing data
-        output_file = os.path.join(root_path, OUTFILE_1_0.format(year, week))
-        if use_existing:
-            try:
-                with open(output_file, 'r') as f:
-                    menu = json.load(f)
-            except FileNotFoundError:
-                menu = {}
-        else:
-            menu = {}
-        for day, day_menu in week_menu.items():
-            if not day_menu["open"]:
-                day_menu1_0 = {"open": False}
-            else:
-                day_menu1_0 = {
-                    "open": True,
-                    "soup": day_menu["soup"][0],
-                    "meat": [day_menu["soup"][1]],
-                    "vegetables": day_menu["vegetables"]
-                }
-                day_menu1_0["meat"][0]["recommended"] = False
-                for meat in day_menu["meat"]:
-                    name = meat["name"]
-                    price = meat["price"]
-                    if "vegetarian" in meat["kind"]:
-                        name = "Veg. " + name
-                    day_menu1_0["meat"].append({
-                        'name': name,
-                        'price': price,
-                        'recommended': False
-                    })
-            menu[str(day)] = day_menu1_0
-
-        write_json_to_file(menu, output_file)
-
-
 def write_2_0(root_path, menus):
     """
     Write the menus for version 2.0 of the API.
@@ -388,7 +351,7 @@ def write_2_0(root_path, menus):
                             kind=meal['kind'],
                             name=meal['name'],
                             price=meal['price'],
-                            type='main',
+                            type='main' if meal['hot'] == 'hot' else 'cold',
                         ))
                     menu['vegetables'] = day_menu['vegetables']
 
@@ -406,7 +369,7 @@ def write_2_0(root_path, menus):
         )
 
 
-def main(output_v1, output_v2):
+def main(output_v2):
     """The main method."""
 
     all_problems = {}
@@ -464,17 +427,14 @@ def main(output_v1, output_v2):
     if all_problems:
         pprint(all_problems, stream=sys.stderr)
 
-    write_1_0(output_v1, menus)
     write_2_0(output_v2, menus)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run main resto scraper')
-    parser.add_argument('v1', help='Folder for v1 output. Will be created if needed.')
     parser.add_argument('v2', help='Folder for v2 output. Will be created if needed.')
     args = parser.parse_args()
 
-    output_path_v1 = os.path.abspath(args.v1)  # Like realpath
     output_path_v2 = os.path.abspath(args.v2)  # Like realpath
 
-    main(output_path_v1, output_path_v2)
+    main(output_path_v2)

--- a/server/scraper/resto/menu_manual.py
+++ b/server/scraper/resto/menu_manual.py
@@ -221,10 +221,24 @@ def corona_closed_for_now(_path, original):
 
 def kantienberg_2020(_path, original):
     return {
-        "message": "Resto Kantienberg blijft voorlopig gesloten tijdens academiejaar 2020-2021.",
+        "message": "Resto Kantienberg blijft gesloten tijdens academiejaar 2020-2021.",
         "date": original["date"],
         "open": False
     }
+
+
+def corona_2020_2021_nl(_path, original):
+    message = "Door de coronamaatregelen veranderen enkele zaken: ter plaatse eten is niet mogelijk " \
+              "(enkel afhalen) en er is een beperkter aanbod."
+    original["message"] = message
+    return original
+
+
+def corona_2020_2021_en(_path, original):
+    message = "Due to the corona measures, some changes are made: only takeaway is possible " \
+              "and the offering is reduced."
+    original["message"] = message
+    return original
 
 
 def create_changes(root_path):
@@ -325,37 +339,61 @@ def create_changes(root_path):
             replacer=corona_heropening_nl,
             resto="nl",
             start=date(2020, 9, 7),
-            end=date(2020, 9, 30),
+            end=date(2020, 9, 20),
             all_days=True
         ),
         ManualChange(
             replacer=corona_heropening_en,
             resto="en",
             start=date(2020, 9, 7),
-            end=date(2020, 9, 30),
+            end=date(2020, 9, 20),
             all_days=True
         ),
         ManualChange(
             replacer=corona_closed_for_now,
             resto="nl-debrug",
             start=date(2020, 9, 7),
-            end=date(2020, 9, 30),
+            end=date(2020, 9, 20),
             all_days=True
         ),
         ManualChange(
             replacer=corona_closed_for_now,
             resto="nl-heymans",
             start=date(2020, 9, 7),
-            end=date(2020, 9, 30),
+            end=date(2020, 9, 20),
             all_days=True
         ),
         ManualChange(
             replacer=kantienberg_2020,
             resto="nl-kantienberg",
             start=date(2020, 9, 7),
-            end=date(2020, 9, 30),
+            end=date(2021, 7, 1),
             all_days=True
         ),
+        ManualChange(
+            replacer=corona_2020_2021_en,
+            resto="en",
+            start=date(2020, 9, 21),
+            end=date(2020, 12, 31)
+        ),
+        ManualChange(
+            replacer=corona_2020_2021_nl,
+            resto="nl",
+            start=date(2020, 9, 21),
+            end=date(2020, 12, 31)
+        ),
+        ManualChange(
+            replacer=corona_2020_2021_nl,
+            resto="nl-debrug",
+            start=date(2020, 9, 21),
+            end=date(2020, 12, 31)
+        ),
+        ManualChange(
+            replacer=corona_2020_2021_nl,
+            resto="nl-heymans",
+            start=date(2020, 9, 21),
+            end=date(2020, 12, 31)
+        )
     ]
 
 

--- a/server/static/resto/meta_2.0.json
+++ b/server/static/resto/meta_2.0.json
@@ -7,8 +7,7 @@
             "longitude": 3.727347,
             "type": "resto",
             "endpoint": "en",
-            "open": {"resto":[["11:15", "14:00"], ["17:30", "21:00"]],
-              "cafetaria":[["11:15", "14:00"], ["17:30", "20:00"]]}
+            "open": {"resto":[["08:30", "15:00"]]}
         },{
             "name": "Resto Campus Sterre",
             "address": "Krijgslaan 281",
@@ -16,8 +15,7 @@
             "longitude": 3.712939,
             "type": "resto",
             "endpoint": "nl",
-            "open": {"resto":[["11:15", "14:00"]],
-              "cafetaria":[["08:30", "14:00"]]}
+            "open": {"resto":[["08:30", "14:00"]]}
         }, {
             "name": "Resto Campus Heymans",
             "address": "Harelbekestraat 70",
@@ -25,8 +23,7 @@
             "longitude": 3.730189,
             "type": "resto",
             "endpoint": "nl-heymans",
-            "open": {"resto":[["11:15", "14:00"]],
-              "cafetaria":[["11:15", "14:00"]]}
+            "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Resto De Brug",
             "address": "Sint-Pietersnieuwstraat 45",
@@ -34,8 +31,8 @@
             "longitude":  3.727147,
             "type": "resto",
             "endpoint": "nl-debrug",
-            "open": {"resto":[["11:15", "14:00"], ["17:30", "21:00"]],
-              "cafetaria":[["11:15", "14:00"], ["17:30", "20:00"]]}
+            "open": {"resto":[["08:30", "15:00"], ["17:30", "21:00"]],
+              "cafetaria":[["08:00", "16:00"]]}
         }, {
             "name": "Resto Campus Merelbeke",
             "address": "Salisburylaan 133, Merelbeke",
@@ -43,8 +40,7 @@
             "longitude": 3.766454,
             "type": "resto",
             "endpoint": "nl",
-            "open": {"resto":[["11:15", "14:00"]],
-              "cafetaria":[["08:30", "14:00"]]}
+            "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Resto Campus Dunant",
             "address": "Henri Dunantlaan 2",
@@ -52,8 +48,7 @@
             "longitude": 3.704017,
             "type": "resto",
             "endpoint": "nl",
-            "open": {"resto":[["11:15", "14:00"]],
-              "cafetaria":[["08:30", "14:00"]]}
+            "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Resto Campus Coupure",
             "address": "Coupure Links 653",
@@ -61,7 +56,7 @@
             "longitude": 3.707671,
             "type": "resto",
             "endpoint": "nl",
-            "open": {"resto":[["11:15", "14:00"]]}
+            "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Resto Kantienberg",
             "address": "Stalhof 45",
@@ -69,16 +64,14 @@
             "longitude": 3.728759,
             "type": "resto",
             "endpoint": "nl-kantienberg",
-            "open": {"resto":[["11:15", "14:00"]],
-              "cafetaria":[["11:15", "14:00"]]}
+            "open": {}
         }, {
-            "name": "Cafetaria Ardoyen",
-            "address": "Technologie Zwijnaarde 904",
+            "name": "Resto Ardoyen",
+            "address": "Technologiepark-Zwijnaarde 75, 9052 Zwijnaarde",
             "latitude": 51.010207,
             "longitude": 3.707660,
-            "type": "cafetaria",
-            "open": {"soepbar":[["08:00", "14:00"]],
-              "kiosk":[["11:00", "15:00"]]}
+            "type": "resto",
+            "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Cafetaria Campus Boekentoren",
             "address": "Blandijnberg 2",
@@ -88,25 +81,25 @@
             "open": {"cafetaria":[["08:00", "14:00"]]}
         }, {
             "name": "Cafetaria Campus UZ Gent",
-            "address": "De Pintelaan 185",
+            "address": "Corneel Heymanslaan",
             "latitude": 51.024360,
             "longitude": 3.723540,
             "type": "cafetaria",
-            "open": {"cafetaria":[["08:00", "14:00"]]}
+            "open": {"cafetaria":[["09:00", "14:30"]]}
         }, {
             "name": "Cafetaria Ledeganck",
             "address": "Ledeganckstraat 35",
             "latitude": 51.036520,
             "longitude": 3.723990,
             "type": "cafetaria",
-            "open": {"cafetaria":[["08:00", "14:00"]]}
+            "open": {"cafetaria":[["08:00", "14:30"]]}
         }, {
             "name": "Cafetaria Campus Aula",
             "address": "Universiteitsstraat 4",
             "latitude": 51.051029,
             "longitude": 3.723928,
             "type": "cafetaria",
-            "open": {"cafetaria":[["08:00", "14:00"]]}
+            "open": {"cafetaria":[["08:00", "14:30"]]}
         }, {
             "name": "Club Het Pand",
             "address": "Onderbergen 1",


### PR DESCRIPTION
API updates for new academic year:

- The meal type `side` is no longer used.
- A new meal type is present: `cold`.
- New endpoint for salad bowls.
- API 1.0 has been retired.

See the API docs for more details.