### PR TITLE
Fix resto week extractor

### DIFF
--- a/server/scraper/resto/menu.py
+++ b/server/scraper/resto/menu.py
@@ -159,7 +159,7 @@ def get_weeks(which):
     r = {}
     for url in week_urls:
         try:
-            week_part = url.split("week")[-1]
+            week_part = url.rsplit("/")[-1].replace("week", "")
             # Strip cyclus part
             iso_week = int(week_part.split("-")[0])
         except Exception:


### PR DESCRIPTION
Since urls now look like this `https://www.ugent.be/student/nl/meer-dan-studeren/resto/weekmenurestocampussterre/week40-cyclus1-week2/vrijdag.htm`, our parser got confused and used the second week as the real week, which is not the case.