### PR TITLE
Re-add resto locations

### DIFF
--- a/server/scraper/resto/menu.py
+++ b/server/scraper/resto/menu.py
@@ -29,6 +29,19 @@ WEEK_MENU_URL = {
     "nl": "https://www.ugent.be/student/nl/meer-dan-studeren/resto/weekmenu"
 }
 
+# These endpoints are copies of another endpoint.
+# While this seems useless, it allows messages per endpoint,
+# which is very useful.
+COPIED_ENDPOINTS = {
+    "nl-debrug": "nl",
+    "nl-heymans": "nl",
+    "nl-dunant": "nl",
+    "nl-coupure": "nl",
+    "nl-sterre": "nl",
+    "nl-ardoyen": "nl",
+    "nl-merelbeke": "nl",
+}
+
 # Day names to day of the week.
 # The keys are the keys from WEEK_MENU_URL.
 # For english:
@@ -494,6 +507,10 @@ def main(output_v2):
 
         if problems:
             all_problems[which] = problems
+
+    # Support copies
+    for copy, original in COPIED_ENDPOINTS.items():
+        menus[copy] = menus[original]
 
     # Print the parsing problems.
     if all_problems:

--- a/server/static/resto/meta_2.0.json
+++ b/server/static/resto/meta_2.0.json
@@ -14,7 +14,7 @@
             "latitude": 51.026024,
             "longitude": 3.712939,
             "type": "resto",
-            "endpoint": "nl",
+            "endpoint": "nl-sterre",
             "open": {"resto":[["08:30", "14:00"]]}
         }, {
             "name": "Resto Campus Heymans",
@@ -22,7 +22,7 @@
             "latitude": 51.026508,
             "longitude": 3.730189,
             "type": "resto",
-            "endpoint": "nl",
+            "endpoint": "nl-heymans",
             "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Resto De Brug",
@@ -30,7 +30,7 @@
             "latitude": 51.045613,
             "longitude":  3.727147,
             "type": "resto",
-            "endpoint": "nl",
+            "endpoint": "nl-debrug",
             "open": {"resto":[["08:30", "15:00"], ["17:30", "21:00"]],
               "cafetaria":[["08:00", "16:00"]]}
         }, {
@@ -39,7 +39,7 @@
             "latitude": 50.998369,
             "longitude": 3.766454,
             "type": "resto",
-            "endpoint": "nl",
+            "endpoint": "nl-merelbeke",
             "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Resto Campus Dunant",
@@ -47,7 +47,7 @@
             "latitude": 51.049023,
             "longitude": 3.704017,
             "type": "resto",
-            "endpoint": "nl",
+            "endpoint": "nl-dunant",
             "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Resto Campus Coupure",
@@ -55,7 +55,7 @@
             "latitude": 51.053252,
             "longitude": 3.707671,
             "type": "resto",
-            "endpoint": "nl",
+            "endpoint": "nl-coupure",
             "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Resto Ardoyen",
@@ -63,7 +63,7 @@
             "latitude": 51.010207,
             "longitude": 3.707660,
             "type": "resto",
-            "endpoint": "nl",
+            "endpoint": "nl-ardoyen",
             "open": {"resto":[["08:30", "15:00"]]}
         }, {
             "name": "Cafetaria Campus Boekentoren",


### PR DESCRIPTION
Re-add endpoints for each resto location.

While by default all locations share a menu, this isn't always the case. Additionally, this will allow us to show messages per location once again.

I'll also update the data repo to backport these changes.